### PR TITLE
:bug: fix: Ensure up-to-date PlaceId is used for route-place mapping and improve transactional consistency

### DIFF
--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Place } from './entities/place.entity';
@@ -22,8 +22,11 @@ export class PlaceService {
   }
 
   // id 기반 장소 상세 조회 (DB 저장 포함)
-  async getPlaceDetails(id: string): Promise<Place> {
-    let place = await this.placeRepository.findOne({ where: { id } });
+  async getPlaceDetails(id: string, manager?: EntityManager): Promise<Place> {
+    const placeRepository =
+      manager?.getRepository(Place) || this.placeRepository;
+
+    let place = await placeRepository.findOne({ where: { id } });
     if (place) {
       console.log('DB에서 장소 조회');
       return place;
@@ -33,7 +36,7 @@ export class PlaceService {
 
     place = mapGoogleDtoToPlaceEntity(data);
 
-    await this.placeRepository.save(place);
+    await placeRepository.save(place);
     console.log('DB에 장소 저장');
     return place;
   }

--- a/src/route/route.controller.ts
+++ b/src/route/route.controller.ts
@@ -22,13 +22,17 @@ export class RouteController {
   }
 
   @Get()
-  findAll(@Query('searchText') searchText: string) {
-    return this.routeService.findAll(searchText);
+  findRoutes(
+    @Query('searchText') searchText?: string,
+    @Query('tagIds') tagIds?: string,
+  ) {
+    const tagIdArray = tagIds ? tagIds.split(',').map(Number) : undefined;
+    return this.routeService.findBySearchText(searchText, tagIdArray);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.routeService.findOne(+id);
+  findRoute(@Param('id') id: string) {
+    return this.routeService.findRoute(+id);
   }
 
   @Patch(':id')

--- a/src/route/route.service.ts
+++ b/src/route/route.service.ts
@@ -73,11 +73,11 @@ export class RouteService {
 
       await queryRunner.manager.save(route);
 
-      const routePlaces = placeIds.map((placeId, idx) => {
-        const place = places.find((p) => p.id === placeId); // placeId 갱신 관련 이슈
+      // getPlaceDetails는 항상 갱신된 placeId를 보장
+      const routePlaces = places.map((place, idx) => {
         return queryRunner.manager.create(RoutePlace, {
           route,
-          place, // undefined (route정보에 undefined)
+          place, // 항상 최신 placeId
           position: idx + 1,
         });
       });
@@ -186,6 +186,7 @@ export class RouteService {
           route: { id: route.id },
         });
 
+        // getPlaceDetails는 항상 갱신된 placeId를 보장
         const places = await Promise.all(
           updateRouteDto.placeIds.map((placeId) =>
             this.placeService.getPlaceDetails(placeId, queryRunner.manager),
@@ -196,11 +197,10 @@ export class RouteService {
           throw new NotFoundException('Some places not found');
         }
 
-        const newRoutePlaces = updateRouteDto.placeIds.map((placeId, idx) => {
-          const place = places.find((p) => p.id === placeId);
+        const newRoutePlaces = places.map((place, idx) => {
           return queryRunner.manager.create(RoutePlace, {
             route,
-            place,
+            place, // 최신 placeId가 반영됨
             position: idx + 1,
           });
         });

--- a/src/route/route.service.ts
+++ b/src/route/route.service.ts
@@ -3,7 +3,7 @@ import { CreateRouteDto } from './dto/create-route.dto';
 import { UpdateRouteDto } from './dto/update-route.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Route } from './entities/route.entity';
-import { In, Like, Repository } from 'typeorm';
+import { DataSource, In, Like, Repository } from 'typeorm';
 import { Member } from 'src/member/entities/member.entity';
 import { Tag } from 'src/tag/entities/tag.entity';
 import { RouteResponseDto } from './dto/route-response.dto';
@@ -15,6 +15,8 @@ import { PlaceService } from 'src/place/place.service';
 @Injectable()
 export class RouteService {
   constructor(
+    private readonly dataSource: DataSource,
+
     @InjectRepository(Route)
     private readonly routeRepository: Repository<Route>,
 
@@ -31,54 +33,84 @@ export class RouteService {
   ) {}
 
   async create(createRouteDto: CreateRouteDto) {
-    const { name, placeIds, tagIds, isPublic, memberId } = createRouteDto;
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-    // 나중에는 인증 관련 절차로 변경
-    const member = await this.memberRepository.findOne({
-      where: { id: memberId },
-    });
+    try {
+      const { name, placeIds, tagIds, isPublic, memberId } = createRouteDto;
 
-    if (!member) {
-      throw new NotFoundException('Member not found');
-    }
-
-    const places = await Promise.all(
-      placeIds.map((placeId) => this.placeService.getPlaceDetails(placeId)),
-    );
-
-    const tags = await this.tagRepository.find({
-      where: { id: In(tagIds) },
-    });
-
-    if (tags.length !== tagIds.length) {
-      throw new NotFoundException('Some tags not found');
-    }
-
-    const route = this.routeRepository.create({
-      name,
-      member,
-      tags,
-      isPublic,
-    });
-    await this.routeRepository.save(route);
-
-    const routePlaces = placeIds.map((placeId, idx) => {
-      const place = places.find((p) => p.id === placeId); // placeId 갱신 관련 이슈 + transaction 원자성 이슈
-      return this.routePlaceRepository.create({
-        route,
-        place, // undefined (route정보에 undefined)
-        position: idx + 1,
+      const member = await queryRunner.manager.findOne(Member, {
+        where: { id: memberId },
       });
-    });
 
-    await this.routePlaceRepository.save(routePlaces);
+      // 나중에는 인증 관련 절차로 변경
+
+      if (!member) {
+        throw new NotFoundException('Member not found');
+      }
+
+      const places = await Promise.all(
+        placeIds.map((placeId) =>
+          this.placeService.getPlaceDetails(placeId, queryRunner.manager),
+        ),
+      );
+
+      const tags = await queryRunner.manager.find(Tag, {
+        where: { id: In(tagIds) },
+      });
+
+      if (tags.length !== tagIds.length) {
+        throw new NotFoundException('Some tags not found');
+      }
+
+      const route = queryRunner.manager.create(Route, {
+        name,
+        member,
+        tags,
+        isPublic,
+      });
+
+      await queryRunner.manager.save(route);
+
+      const routePlaces = placeIds.map((placeId, idx) => {
+        const place = places.find((p) => p.id === placeId); // placeId 갱신 관련 이슈
+        return queryRunner.manager.create(RoutePlace, {
+          route,
+          place, // undefined (route정보에 undefined)
+          position: idx + 1,
+        });
+      });
+
+      await queryRunner.manager.save(routePlaces);
+
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
   }
 
   // 검색어 및 태그 (지금은 검색어만 구현)
-  async findAll(searchText: string): Promise<RouteResponseDto[]> {
+  async findBySearchText(
+    searchText?: string,
+    tagIds?: number[],
+  ): Promise<RouteResponseDto[]> {
+    // 1. tagIds에 해당하는 Route id만 먼저 조회
+    const routeIds = await this.routeRepository
+      .createQueryBuilder('route')
+      .leftJoin('route.tags', 'tag')
+      .where('tag.id IN (:...tagIds)', { tagIds })
+      .getMany()
+      .then((routes) => routes.map((r) => r.id));
+
+    // 2. 해당 Route id로 전체 태그 포함 조회
     const routes = await this.routeRepository.find({
       where: {
-        name: Like(`%${searchText}%`),
+        id: In(routeIds),
+        name: searchText ? Like(`%${searchText}%`) : undefined,
       },
       relations: ['routePlaces', 'routePlaces.place', 'tags', 'member'],
     });
@@ -91,7 +123,7 @@ export class RouteService {
     });
   }
 
-  async findOne(id: number): Promise<RouteResponseDto> {
+  async findRoute(id: number): Promise<RouteResponseDto> {
     const route = await this.routeRepository.findOne({
       where: { id },
       relations: ['routePlaces', 'routePlaces.place', 'tags', 'member'],
@@ -109,58 +141,80 @@ export class RouteService {
   }
 
   async update(id: number, updateRouteDto: UpdateRouteDto) {
-    const route = await this.routeRepository.findOne({
-      where: { id },
-      relations: ['routePlaces', 'tags', 'member'],
-    });
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-    if (!route) {
-      throw new NotFoundException('Route not found');
-    }
-
-    if (updateRouteDto.name !== undefined) {
-      route.name = updateRouteDto.name;
-    }
-
-    if (updateRouteDto.isPublic !== undefined) {
-      route.isPublic = updateRouteDto.isPublic;
-    }
-
-    if (updateRouteDto.tagIds) {
-      const tags = await this.tagRepository.find({
-        where: { id: In(updateRouteDto.tagIds) },
+    try {
+      // 1. Route 조회
+      const route = await queryRunner.manager.findOne(Route, {
+        where: { id },
+        relations: ['routePlaces', 'tags', 'member'],
       });
-
-      if (tags.length !== updateRouteDto.tagIds.length) {
-        throw new NotFoundException('Some tags not found');
+      if (!route) {
+        throw new NotFoundException('Route not found');
       }
 
-      route.tags = tags;
-    }
-
-    if (updateRouteDto.placeIds) {
-      await this.routePlaceRepository.delete({ route: { id: route.id } });
-
-      const places = await Promise.all(
-        updateRouteDto.placeIds.map((placeId) =>
-          this.placeService.getPlaceDetails(placeId),
-        ),
-      );
-
-      if (places.length !== updateRouteDto.placeIds.length) {
-        throw new NotFoundException('Some places not found');
+      // 2. 필드 변경
+      if (updateRouteDto.name !== undefined) {
+        route.name = updateRouteDto.name;
       }
 
-      const newRoutePlaces = updateRouteDto.placeIds.map((placeId, idx) => {
-        const place = places.find((p) => p.id === placeId);
-        return this.routePlaceRepository.create({
-          route,
-          place,
-          position: idx + 1,
+      if (updateRouteDto.isPublic !== undefined) {
+        route.isPublic = updateRouteDto.isPublic;
+      }
+
+      // 3. 태그 변경
+      if (updateRouteDto.tagIds) {
+        const tags = await queryRunner.manager.find(Tag, {
+          where: { id: In(updateRouteDto.tagIds) },
         });
-      });
 
-      await this.routePlaceRepository.save(newRoutePlaces);
+        if (tags.length !== updateRouteDto.tagIds.length) {
+          throw new NotFoundException('Some tags not found');
+        }
+
+        route.tags = tags;
+      }
+
+      // 4. Route 수정사항 반영
+      await queryRunner.manager.save(route);
+
+      // 5. Route-Place 관계 변경
+      if (updateRouteDto.placeIds) {
+        await queryRunner.manager.delete(RoutePlace, {
+          route: { id: route.id },
+        });
+
+        const places = await Promise.all(
+          updateRouteDto.placeIds.map((placeId) =>
+            this.placeService.getPlaceDetails(placeId, queryRunner.manager),
+          ),
+        );
+
+        if (places.length !== updateRouteDto.placeIds.length) {
+          throw new NotFoundException('Some places not found');
+        }
+
+        const newRoutePlaces = updateRouteDto.placeIds.map((placeId, idx) => {
+          const place = places.find((p) => p.id === placeId);
+          return queryRunner.manager.create(RoutePlace, {
+            route,
+            place,
+            position: idx + 1,
+          });
+        });
+
+        await queryRunner.manager.save(RoutePlace, newRoutePlaces);
+      }
+      // 커밋
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      // 롤백
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
     }
   }
 

--- a/src/tag/entities/tag.entity.ts
+++ b/src/tag/entities/tag.entity.ts
@@ -6,7 +6,7 @@ export class Tag {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({ unique: true })
   name: string;
 
   @ManyToMany(() => Route, (route) => route.tags)


### PR DESCRIPTION
## 📋 PR 유형
PR 유형을 선택합니다.
- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔍 관련 이슈
- Route와 Place 매핑 시 placeId 동기화 문제
- 태그 기반 검색 시 전체 태그 미포함 문제
- 트랜잭션 일관성 부족

## 📕 작업 내역
- Google Places API에서 반환되는 최신 placeId를 기준으로 route-place를 생성/수정하도록 로직 개선 (undefined 방지)
- create, update 모두에서 placeId 매칭 방식 제거 및 Promise.all 결과의 Place 객체를 그대로 사용하도록 변경
- 모든 생성/수정 로직에 QueryRunner 기반 트랜잭션 적용으로 원자성 보장
- 태그 기반 검색 시 2-step 쿼리 적용: tagIds로 Route id 조회 후, 전체 태그/관계 포함해 재조회하여 전체 태그가 응답에 포함되도록 개선
- 컨트롤러 네이밍 및 검색/조회 로직 리팩토링

## 특별히 봐줬으면 하는 부분
- route-place 생성/수정 시 항상 DB에 저장된 최신 Place 정보를 사용하도록 변경된 부분
- 태그 기반 검색 결과에 전체 태그가 포함되는지
  - 루트 A가 태그 1, 2, 3을 가지고 있고,
    사용자가 tagIds=2로 검색하면
    2-step 쿼리를 적용하기 전에는 응답에 tags: [2]만 포함되어 루트 A의 전체 태그를 볼 수 없었음
    개선 후에는 tags: [1, 2, 3]처럼 해당 Route가 실제로 가지고 있는 모든 태그가 응답에 포함됨

## ⚠️ 추가적으로 설명할 내용
- 없음
