### PR TITLE
:sparkles: feat: Introduce in-memory caching for place details and refactor route search logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -16,6 +17,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
         "axios": "^1.9.0",
+        "cache-manager": "^6.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "mysql2": "^3.14.1",
@@ -1908,6 +1910,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
+      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@keyv/serialize/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -2220,6 +2255,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz",
+      "integrity": "sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -5310,6 +5358,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cache-manager": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-6.4.3.tgz",
+      "integrity": "sha512-VV5eq/QQ5rIVix7/aICO4JyvSeEv9eIQuKL5iFwgM2BrcYoE0A/D1mNsAHJAsB0WEbNdBlKkn6Tjz6fKzh/cKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyv": "^5.3.3"
+      }
+    },
+    "node_modules/cache-manager/node_modules/keyv": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.3.tgz",
+      "integrity": "sha512-Rwu4+nXI9fqcxiEHtbkvoes2X+QfkTRo1TMkPfwzipGsJlJO/z69vqB4FNl9xJ3xCpAcbkvmEabZfPzrwN3+gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.0.3"
       }
     },
     "node_modules/cacheable-lookup": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -27,6 +28,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
     "axios": "^1.9.0",
+    "cache-manager": "^6.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "mysql2": "^3.14.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,12 +5,21 @@ import { DatabaseModule } from './database/database.module';
 import { MemberModule } from './member/member.module';
 import { PlaceModule } from './place/place.module';
 import { RouteModule } from './route/route.module';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TagModule } from './tag/tag.module';
+import { CacheModule } from '@nestjs/cache-manager';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    CacheModule.registerAsync({
+      isGlobal: true,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        ttl: parseInt(configService.get('CACHE_TTL', '604800'), 10), // 7일
+        max: parseInt(configService.get('CACHE_MAX', '1000'), 10),
+      }),
+    }),
     DatabaseModule,
     MemberModule,
     PlaceModule,

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -1,5 +1,5 @@
 import { EntityManager, Repository } from 'typeorm';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Place } from './entities/place.entity';
 import { PlaceResponseDto } from './dto/place-response.dto';
@@ -8,10 +8,15 @@ import {
   searchPlacesFromGoogle,
 } from '../util/googlePlacesApi.util';
 import { mapGoogleDtoToPlaceEntity } from 'src/util/placeMapper.util';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 
 @Injectable()
 export class PlaceService {
   constructor(
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager: Cache,
+
     @InjectRepository(Place)
     private readonly placeRepository: Repository<Place>,
   ) {}
@@ -23,21 +28,35 @@ export class PlaceService {
 
   // id 기반 장소 상세 조회 (DB 저장 포함)
   async getPlaceDetails(id: string, manager?: EntityManager): Promise<Place> {
+    // 캐시 조회
+    let place = await this.cacheManager.get<Place>(`place:${id}`);
+    if (place) {
+      console.log(`캐시에서 장소 조회: ${id}`);
+      return place;
+    }
+
+    // DB 조회
     const placeRepository =
       manager?.getRepository(Place) || this.placeRepository;
 
-    let place = await placeRepository.findOne({ where: { id } });
+    place = await placeRepository.findOne({ where: { id } });
     if (place) {
       console.log('DB에서 장소 조회');
       return place;
     }
 
+    // Google Place API 조회
     const data: PlaceResponseDto = await fetchPlaceDetailsFromGoogle(id);
 
+    // DTO 전환
     place = mapGoogleDtoToPlaceEntity(data);
 
+    // DB 저장
     await placeRepository.save(place);
     console.log('DB에 장소 저장');
+
+    await this.cacheManager.set(`place:${id}`, place);
+    console.log('캐시에 장소 저장');
     return place;
   }
 }

--- a/src/route/route.controller.ts
+++ b/src/route/route.controller.ts
@@ -27,7 +27,7 @@ export class RouteController {
     @Query('tagIds') tagIds?: string,
   ) {
     const tagIdArray = tagIds ? tagIds.split(',').map(Number) : undefined;
-    return this.routeService.findBySearchText(searchText, tagIdArray);
+    return this.routeService.findRoutes(searchText, tagIdArray);
   }
 
   @Get(':id')


### PR DESCRIPTION
## 📋 PR 유형
PR 유형을 선택합니다.
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔍 관련 이슈
- 추후 Redis로 전환

## 📕 작업 내역
- PlaceService에 인메모리 캐싱을 도입하여 장소 상세 정보를 캐시하도록 구현
- RouteService가 PlaceService의 캐싱된 데이터를 활용해 중복 DB/외부 API 호출을 최소화
- findBySearchText → findRoutes로 메서드명 통일 및 검색 로직 개선

## 특별히 봐줬으면 하는 부분
- 캐싱된 place 정보가 정상적으로 반영되는지
- 검색 로직 및 응답 데이터의 일관성
- 기존 기능과의 호환성

## ⚠️ 추가적으로 설명할 내용
- 캐싱 구현은 추후 Redis 등 외부 캐시로 확장하기 쉽게 설계함
- .env에 `CACHE_TTL=604800`, `CACHE_MAX=1000` 추가 필요